### PR TITLE
Helm Chart & Automated Release

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,0 +1,31 @@
+name: Release Charts
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ Now, open your favorite browser and enter the url of dailyclean-api service : ht
 
 Enjoy dailyclean !!!!
 
+## Deploy using Helm
+
+Add the helm repository, update and install the chart:
+```bash
+helm repo add dailyclean https://axafrance.github.io/dailyclean/
+helm repo update
+helm install dailyclean dailyclean/dailyclean
+```
+
+Check the [values.yaml](./charts/dailyclean/values.yaml) file to see the available configuration options.
+
 ## How Does It Work
 
 - Daily clean use native kubernetes API, it works with any kubernetes projects. 

--- a/charts/dailyclean/.helmignore
+++ b/charts/dailyclean/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/dailyclean/Chart.yaml
+++ b/charts/dailyclean/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: dailyclean
+description: A Helm chart to deploy the dailyclean application
+type: application
+version: 0.0.1

--- a/charts/dailyclean/templates/_helpers.tpl
+++ b/charts/dailyclean/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dailyclean.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dailyclean.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dailyclean.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "dailyclean.labels" -}}
+helm.sh/chart: {{ include "dailyclean.chart" . }}
+{{ include "dailyclean.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "dailyclean.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dailyclean.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/charts/dailyclean/templates/deployment.yaml
+++ b/charts/dailyclean/templates/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dailyclean.fullname" . }}
+  labels:
+    axa.com/dailyclean: 'false'
+    {{- include "dailyclean.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "dailyclean.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "dailyclean.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "dailyclean.fullname" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: SERVICE_JOB_IMAGENAME
+              value: {{ .Values.image.serviceJobImageName }}
+            - name: SERVICE_JOB_SERVICEACCOUNTNAME
+              value: {{ include "dailyclean.fullname" . }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/dailyclean/templates/ingress.yaml
+++ b/charts/dailyclean/templates/ingress.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "dailyclean.fullname" . }}
+  labels:
+    {{- include "dailyclean.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+{{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "dailyclean.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end -}}

--- a/charts/dailyclean/templates/route.yaml
+++ b/charts/dailyclean/templates/route.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.route.enabled -}}
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ include "dailyclean.fullname" . }}
+  labels:
+    {{- include "dailyclean.labels" . | nindent 4 }}
+    router: {{ .Values.route.router }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  host: {{ .Values.route.host }}
+  to:
+    kind: Service
+    name: {{ include "dailyclean.fullname" . }}
+  port:
+    targetPort: {{ .Values.service.port }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+{{- end }}

--- a/charts/dailyclean/templates/service.yaml
+++ b/charts/dailyclean/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dailyclean.fullname" . }}
+  labels:
+    {{- include "dailyclean.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "dailyclean.selectorLabels" . | nindent 4 }}

--- a/charts/dailyclean/templates/serviceaccount.yaml
+++ b/charts/dailyclean/templates/serviceaccount.yaml
@@ -1,0 +1,83 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "dailyclean.fullname" . }}
+  labels:
+    {{- include "dailyclean.labels" . | nindent 4 }}
+rules:
+  - verbs:
+      - create
+    apiGroups:
+      - ''
+    resources:
+      - pods/exec
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - pods
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+  - verbs:
+      - get
+      - list
+      - watch
+      - patch
+    apiGroups:
+      - apps
+      - extensions
+    resources:
+      - deployments
+      - replicasets
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - apps
+    resources:
+      - statefulsets
+  - verbs:
+      - get
+      - create
+      - patch
+      - update
+      - delete
+      - list
+      - watch
+    apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dailyclean.fullname" . }}
+  labels:
+    {{- include "dailyclean.labels" . | nindent 4 }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "dailyclean.fullname" . }}
+  labels:
+    {{- include "dailyclean.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dailyclean.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "dailyclean.fullname" . }}

--- a/charts/dailyclean/templates/serviceaccount.yaml
+++ b/charts/dailyclean/templates/serviceaccount.yaml
@@ -42,6 +42,7 @@ rules:
       - get
       - list
       - watch
+      - patch
     apiGroups:
       - apps
     resources:

--- a/charts/dailyclean/templates/tests/test-connection.yaml
+++ b/charts/dailyclean/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "dailyclean.fullname" . }}-test-connection"
+  labels:
+    {{- include "dailyclean.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "dailyclean.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/dailyclean/values.yaml
+++ b/charts/dailyclean/values.yaml
@@ -1,0 +1,54 @@
+# Default values for dailyclean.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: axaguildev/dailyclean-api
+  tag: "latest"
+  pullPolicy: IfNotPresent
+  serviceJobImageName: "axaguildev/dailyclean-job:latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8080
+
+route:
+  enabled: false
+  router: "internal"
+  annotations: {}
+  host: chart-example.local
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  host: chart-example.local
+  tls:
+    enabled: false
+    secretName: chart-example-tls
+
+resources:
+  limits:
+    memory: "96Mi"
+    cpu: "50m"
+  requests:
+    memory: "96Mi"
+    cpu: "10m"


### PR DESCRIPTION
## 🚀 New Feature: Helm Chart & Automated Release

### What's changed:

1. **Helm Chart Added**: I've added a new Helm chart to the repository. This will allow users to easily deploy the application using Helm.
  
2. **GitHub Action with Helm Chart Releaser**: To ensure that our Helm chart is automatically released, I've integrated `helm/chart-releaser-action`. This GitHub action will package the Helm chart and release it using GitHub Pages every time there's a change.

   - 📖 According to the [official documentation](https://github.com/helm/chart-releaser-action#pre-requisites), for this to function properly, we need to set up GitHub Pages with the `gh-pages` branch. I recommend verifying this configuration in the repository settings.

### Next Steps:

- Review and merge this PR.
- Create a new branch `gh-pages` from `main` and ensure that the branch is set as the source branch for GitHub Pages in the repository settings.

Looking forward to feedback and suggestions!
